### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -1,4 +1,6 @@
 name: C/C++ CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BlackWyrm18/Zenith/security/code-scanning/1](https://github.com/BlackWyrm18/Zenith/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and builds it (does not push, create releases, or interact with issues or pull requests), the minimal required permission is `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level. The best practice is to set it at the workflow level, immediately after the `name` field and before `on:`. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
